### PR TITLE
Add user bookmark functionality for assets

### DIFF
--- a/contracts/digital-asset-manager.clar
+++ b/contracts/digital-asset-manager.clar
@@ -184,3 +184,55 @@
   )
 )
 
+
+;;-----------------------------------------------------------------------------
+;; User Preference Functions
+;;-----------------------------------------------------------------------------
+
+;; Add asset to personal bookmarks
+(define-public (bookmark-asset (asset-id uint))
+  (let
+    (
+      (asset-data (unwrap! (map-get? asset-catalog { asset-id: asset-id }) RESP_ASSET_MISSING))
+    )
+    ;; Validation checks
+    (asserts! (asset-exists? asset-id) RESP_ASSET_MISSING)
+    (asserts! (has-viewing-rights? asset-id tx-sender) RESP_NO_ACCESS)
+    (asserts! (not (is-bookmarked? asset-id tx-sender)) RESP_BOOKMARK_EXISTS)
+
+    ;; Record bookmark
+    (map-insert bookmark-registry
+      { viewer: tx-sender, asset-id: asset-id }
+      {
+        created: block-height,
+        modified: block-height
+      }
+    )
+    (ok true)
+  )
+)
+
+;; Remove asset from personal bookmarks
+(define-public (remove-bookmark (asset-id uint))
+  (let
+    (
+      (asset-data (unwrap! (map-get? asset-catalog { asset-id: asset-id }) RESP_ASSET_MISSING))
+    )
+    ;; Validation checks
+    (asserts! (asset-exists? asset-id) RESP_ASSET_MISSING)
+    (asserts! (is-bookmarked? asset-id tx-sender) RESP_NOT_BOOKMARKED)
+
+    ;; Remove bookmark
+    (map-delete bookmark-registry { viewer: tx-sender, asset-id: asset-id })
+    (ok true)
+  )
+)
+
+;; Check bookmark status for current user
+(define-read-only (get-bookmark-status (asset-id uint))
+  (ok (is-bookmarked? asset-id tx-sender))
+)
+
+
+
+


### PR DESCRIPTION
Standard PR Description:
This PR introduces functions for users to manage bookmarks on assets. It includes:

bookmark-asset: Allows users to add an asset to their personal bookmarks after validating permissions and existence.
remove-bookmark: Enables users to remove an asset from their bookmarks if it is currently bookmarked.
get-bookmark-status: Provides a read-only function to check if an asset is bookmarked by the user.
Validation checks ensure that assets exist, users have the right permissions, and prevent duplicate bookmarks.